### PR TITLE
Fixed bug with a `Vector{FutureValue}` input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 0.1.2 (2026-03-04)
+
+### Bugfix
+
+* Fixed a bug when the `FutureValue` vector was of type `Vector{FutureValue}`.
+
 ## Version 0.1.1 (2025-04-25)
 
 * Introduction of `TypeFutureValue` for assigning a value to a variable for all instances of a given nodal type.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsRecedingHorizon"
 uuid = "37ec17de-8561-4b6b-83ee-0529988fea82"
 authors = ["Lucas Ferreira Bernadino, Julian Straus, Halvor Aarnes Krog"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/model.jl
+++ b/src/model.jl
@@ -254,7 +254,7 @@ function EMB.objective_operational(
     # Calculate the value for the future value
     future_value = JuMP.Containers.DenseAxisArray[]
     for val_type ∈ val_types
-        𝒱ˢᵘᵇ = filter(v -> typeof(v) == val_type, 𝒱)
+        𝒱ˢᵘᵇ = convert(Vector{val_type}, filter(v -> typeof(v) == val_type, 𝒱))
         push!(future_value, get_future_value_expression(m, 𝒱ˢᵘᵇ, 𝒯ᴵⁿᵛ, modeltype))
     end
 

--- a/src/utils/other.jl
+++ b/src/utils/other.jl
@@ -42,7 +42,6 @@ end
     _update_future_value!(𝒮ᵛ::Vector{FutureValueSub{T}}, time_elapsed::Real) where {T<:StorageValueCuts}
     _update_future_value!(𝒮ᵛ::Vector{FutureValueSub{T}}, time_elapsed::Real) where {T<:TypeFutureValue}
 
-
 Update the value of [`TimeWeightReset`](@ref) based on the time `time_elapsed` at the end of
 the TimeStructure.
 

--- a/test/test_future_value.jl
+++ b/test/test_future_value.jl
@@ -412,7 +412,7 @@ end
             Direct("src_b-snk_b", src_b, snk_b),
         ]
 
-        𝒱 = [
+        𝒱 = FutureValue[
             TypeFutureValue(RefSource, :cap_use, -2),
             TypeFutureValue(RefSink, :cap_use, 10),
         ]


### PR DESCRIPTION
## Problem statement

The dispatch in the function `get_future_value_expression` is not working when the input to the `Case` type is a `Vector{FutureValue}`. This is caused by the filter *[in the function `objective_operational`](https://github.com/EnergyModelsX/EnergyModelsRecedingHorizon.jl/blob/1ac2e510a599d759181a2edd248df383aaf25d78/src/model.jl#L257) as it returns as well a `Vector{FutureValue}` as can be tested with this minimum working example:

```julia
vec = Real[1, 2, 3, 4.0]
typeof(vec) # Provides `Vector{Real}`

filter(n -> isa(n, Int64), vec) # Provides still a `Vector{Real}`
```

## Solution

Convert the vector to the corresponding type. As we filter, there is no problem. The change in the test tests this behavior.