### PR TITLE
Adjustment to changes in EMB v0.10

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## Version 0.2.0 (2026-04-15)
+
+* Adjusted to [`EnergyModelsBase` v0.10.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0):
+  * Model worked without adjustments.
+  * Test set was adjusted as implemented nodes did not adhere to definition of nodes.
+* Breaking change still included to maintain the possibility to do bug fixes in version 0.1.x for existing models with `EnergyModelsBase` v0.9.x.
+
 ## Version 0.1.2 (2026-03-04)
 
 ### Bugfix

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsRecedingHorizon"
 uuid = "37ec17de-8561-4b6b-83ee-0529988fea82"
 authors = ["Lucas Ferreira Bernadino, Julian Straus, Halvor Aarnes Krog"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -24,8 +24,8 @@ EMGPOIExt = ["EnergyModelsGeography", "ParametricOptInterface"]
 Accessors = "0.1.42"
 CSV = "0.10.15"
 DataFrames = "1.7.0"
-EnergyModelsBase = "0.9.0"
-EnergyModelsGeography = "0.11.0"
+EnergyModelsBase = "0.10"
+EnergyModelsGeography = "0.12"
 JuMP = "1.24"
 ParametricOptInterface = "0.9"
 TimeStruct = "0.9.1"

--- a/examples/new_initial_data_type.jl
+++ b/examples/new_initial_data_type.jl
@@ -35,6 +35,8 @@ struct NodeNewInitData{T<:Real} <: EMB.Node
 end
 
 # Create function dispatches so that corresponding model variables are not created
+EMB.inputs(n::NodeNewInitData) = Resource[]
+EMB.outputs(n::NodeNewInitData) = Resource[]
 EMB.has_input(n::NodeNewInitData) = false
 EMB.has_output(n::NodeNewInitData) = false
 EMB.has_opex(n::NodeNewInitData) = false

--- a/examples/node_with_initial_data.jl
+++ b/examples/node_with_initial_data.jl
@@ -33,6 +33,8 @@ struct IncrementInitNode{T<:Real} <: EMB.Node
 end
 
 # Create function dispatches so that corresponding model variables are not created
+EMB.inputs(n::IncrementInitNode) = Resource[]
+EMB.outputs(n::IncrementInitNode) = Resource[]
 EMB.has_input(n::IncrementInitNode) = false
 EMB.has_output(n::IncrementInitNode) = false
 EMB.has_opex(n::IncrementInitNode) = false

--- a/src/model.jl
+++ b/src/model.jl
@@ -232,7 +232,7 @@ end
     EMB.objective_operational(m, 𝒱::Vector{<:FutureValue}, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::EnergyModel)
 
 Create JuMP expressions indexed over the investment periods `𝒯ᴵⁿᵛ` for different elements.
-The expressions correspond to the operational expenses of the different elements.
+The expressions correspond to the operating expenses of the different elements.
 The expressions are not discounted and do not take the duration of the investment periods
 into account.
 

--- a/test/test_init_data.jl
+++ b/test/test_init_data.jl
@@ -136,6 +136,8 @@ end
         return case, model
     end
 
+    EMB.inputs(n::SampleInitNode) = Resource[]
+    EMB.outputs(n::SampleInitNode) = Resource[]
     EMB.has_input(n::SampleInitNode) = false
     EMB.has_output(n::SampleInitNode) = false
     EMB.has_opex(n::SampleInitNode) = false


### PR DESCRIPTION
This PR increases the compatibility for `EnergyModelsBase` due to the version increase to *[v0.10.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0)*.

> [!IMPORTANT]  
> The changes related to early retirement do not change the behavior in `EnergyModelsRecedingHorizon`. However, to keep backwards bug fix possibilities, it is better to still have a major version increase.
>
> The changes in the test structure is due to the nodes not following the standard design.