### PR TITLE
Bugfix: Undefined variable in `POIExt`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Release notes
 
+
+## Version 0.2.2 (2026-06-24)
+
+### Bugfix
+* Fixed undefined variable 𝒽 in POIExt/model.jl and used 𝒽₀ instead.
+* Fixed undefined variable op_per_strat in POIExt/model.jl.
+
+
 ## Version 0.2.1 (2026-06-21)
 
 * Restructured internal function structure:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,10 @@
 # Release notes
 
-
 ## Version 0.2.2 (2026-06-24)
 
 ### Bugfix
 * Fixed undefined variable 𝒽 in POIExt/model.jl and used 𝒽₀ instead.
 * Fixed undefined variable op_per_strat in POIExt/model.jl.
-
 
 ## Version 0.2.1 (2026-06-21)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsRecedingHorizon"
 uuid = "37ec17de-8561-4b6b-83ee-0529988fea82"
 authors = ["Lucas Ferreira Bernadino, Julian Straus, Halvor Aarnes Krog"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/ext/POIExt/model.jl
+++ b/ext/POIExt/model.jl
@@ -45,7 +45,7 @@ function EMRH.run_model_rh(
     # Extract the time structure from the case to identify the used operational periods
     # and the receding horizon time structure
     if use_op_per_strat
-        𝒯ᵣₕ = TwoLevel(1, 1, SimpleTimes(durations(𝒽)); op_per_strat)
+        𝒯ᵣₕ = TwoLevel(1, 1, SimpleTimes(durations(𝒽₀)); op_per_strat)
     else
         𝒯ᵣₕ = TwoLevel(1, sum(durations(𝒽₀)), SimpleTimes(durations(𝒽₀)))
     end

--- a/ext/POIExt/model.jl
+++ b/ext/POIExt/model.jl
@@ -23,6 +23,8 @@ function EMRH.run_model_rh(
     ℋ = case.misc[:horizons]
     𝒽₀ = first(ℋ)
     n_𝒽 = length(ℋ)
+    op_per_strat = 𝒯.op_per_strat
+
 
     # Assert that the horizon is functioning with the POI implementation.
     horizon_duration = all(


### PR DESCRIPTION
This PR fixes two bugs in POIExt that occured during the previous PR:

- Fix undefined variable 𝒽 and use 𝒽₀ instead
- Define op_per_strat variable as previously undefined